### PR TITLE
Example of using your own summary notification

### DIFF
--- a/Examples/AndroidStudio/app/src/main/AndroidManifest.xml
+++ b/Examples/AndroidStudio/app/src/main/AndroidManifest.xml
@@ -40,6 +40,8 @@
                 <action android:name="com.onesignal.NotificationExtender" />
             </intent-filter>
         </service>
+
+        <receiver android:name=".SummaryNotificationReceiver" />
     </application>
 
 </manifest>

--- a/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/ExampleApplication.java
+++ b/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/ExampleApplication.java
@@ -1,6 +1,7 @@
 package com.onesignal.example;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
@@ -13,9 +14,13 @@ import org.json.JSONObject;
 
 public class ExampleApplication extends Application {
 
+   public static Context applicationContext;
+
    @Override
    public void onCreate() {
       super.onCreate();
+
+      applicationContext = this;
 
       // Logging set to help debug issues, remove before releasing your app.
       //OneSignal.setLogLevel(OneSignal.LOG_LEVEL.VERBOSE, OneSignal.LOG_LEVEL.WARN);
@@ -64,6 +69,9 @@ public class ExampleApplication extends Application {
       // This fires when a notification is opened by tapping on it.
       @Override
       public void notificationOpened(OSNotificationOpenResult result) {
+         NotificationUtils.cancelSummaryNotificationIfNoChildren(applicationContext);
+
+
          OSNotificationAction.ActionType actionType = result.action.type;
          JSONObject data = result.notification.payload.additionalData;
          String launchUrl = result.notification.payload.launchURL; // update docs launchUrl

--- a/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/NotificationExtenderExample.java
+++ b/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/NotificationExtenderExample.java
@@ -1,31 +1,57 @@
 package com.onesignal.example;
 
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.os.Build;
 import android.support.v4.app.NotificationCompat;
-import android.util.Log;
+import android.support.v4.app.NotificationManagerCompat;
 
 import com.onesignal.NotificationExtenderService;
-import com.onesignal.OSNotificationDisplayedResult;
 import com.onesignal.OSNotificationReceivedResult;
 
 import java.math.BigInteger;
 
 public class NotificationExtenderExample extends NotificationExtenderService {
+
+   private static String NOTIFICATION_CHANNEL = "fcm_fallback_notification_channel";
+   private static String NOTIFICATION_GROUP_KEY = "test";
+   static int NOTIFICATION_GROUP_ID = 1234;
+
    @Override
    protected boolean onNotificationProcessing(OSNotificationReceivedResult receivedResult) {
-      // Read Properties from result
       OverrideSettings overrideSettings = new OverrideSettings();
       overrideSettings.extender = new NotificationCompat.Extender() {
          @Override
          public NotificationCompat.Builder extend(NotificationCompat.Builder builder) {
-            // Sets the background notification color to Red on Android 5.0+ devices.
-            return builder.setColor(new BigInteger("FFFF0000", 16).intValue());
+            return builder.setGroup(NOTIFICATION_GROUP_KEY);
          }
       };
 
-      OSNotificationDisplayedResult displayedResult = displayNotification(overrideSettings);
-      Log.d("OneSignalExample", "Notification displayed with id: " + displayedResult.androidNotificationId);
+      displayNotification(overrideSettings);
+      displaySummaryNotification();
 
       // Return true to stop the notification from displaying
       return true;
+   }
+
+   private void displaySummaryNotification() {
+      // Android pre-7.0 would keep notifications individual, however on newer versions they auto group.
+      //   The auto grouping behavior isn't desirable since it does not put any data on the intent.
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
+         return;
+
+      Intent intent = new Intent(this, SummaryNotificationReceiver.class);
+      PendingIntent pendingIntent = PendingIntent.getBroadcast(this, 1, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+
+      NotificationCompat.Builder summmaryBuilder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL);
+      summmaryBuilder
+         .setColor(new BigInteger("FFFF0000", 16).intValue())
+         .setSmallIcon(android.R.drawable.ic_popup_reminder)
+         .setContentText("This Summary Text should NOT be seen.")
+         .setGroup(NOTIFICATION_GROUP_KEY)
+         .setContentIntent(pendingIntent)
+         .setGroupSummary(true);
+
+      NotificationManagerCompat.from(this).notify(NOTIFICATION_GROUP_ID, summmaryBuilder.build());
    }
 }

--- a/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/NotificationUtils.java
+++ b/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/NotificationUtils.java
@@ -1,0 +1,59 @@
+package com.onesignal.example;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.os.Build;
+import android.service.notification.StatusBarNotification;
+import android.support.annotation.RequiresApi;
+
+import java.util.TreeMap;
+
+class NotificationUtils {
+
+   static class ChildNotification {
+      int id;
+      PendingIntent contentIntent;
+
+      ChildNotification(int id, PendingIntent contentIntent) {
+         this.id = id; this.contentIntent = contentIntent;
+      }
+   }
+
+   @RequiresApi(api = Build.VERSION_CODES.M)
+   static TreeMap<Long, ChildNotification> getTreeMapOfChildNotifications(Context context) {
+      NotificationManager notifManager = (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
+      StatusBarNotification[] activeNotifs = notifManager.getActiveNotifications();
+
+      // Create SortedMap so we can sort notifications based on display time
+      TreeMap<Long, ChildNotification> activeChildNotifs = new TreeMap<>();
+      for (StatusBarNotification activeNotif : activeNotifs) {
+         if (isGroupSummary(activeNotif))
+            continue;
+         ChildNotification childNotification = new ChildNotification(activeNotif.getId(), activeNotif.getNotification().contentIntent);
+         activeChildNotifs.put(activeNotif.getNotification().when, childNotification);
+      }
+
+      return activeChildNotifs;
+   }
+
+   @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+   static boolean isGroupSummary(StatusBarNotification notif) {
+      return (notif.getNotification().flags & Notification.FLAG_GROUP_SUMMARY) != 0;
+   }
+
+   static void cancelNotification(Context context, int id) {
+      NotificationManager notifManager = (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
+      notifManager.cancel(id);
+   }
+
+   // Call from either your NotificationOpenedHandler or each time your app is resumed
+   static void cancelSummaryNotificationIfNoChildren(Context context) {
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
+         return;
+
+      if (getTreeMapOfChildNotifications(context).size() == 0)
+         cancelNotification(context, NotificationExtenderExample.NOTIFICATION_GROUP_ID);
+   }
+}

--- a/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/SummaryNotificationReceiver.java
+++ b/Examples/AndroidStudio/app/src/main/java/com/onesignal/example/SummaryNotificationReceiver.java
@@ -1,0 +1,30 @@
+package com.onesignal.example;
+
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Build;
+import android.support.annotation.RequiresApi;
+
+import java.util.TreeMap;
+
+public class SummaryNotificationReceiver extends BroadcastReceiver {
+
+   @RequiresApi(api = Build.VERSION_CODES.M)
+   @Override
+   public void onReceive(Context context, Intent intent) {
+      TreeMap<Long, NotificationUtils.ChildNotification> activeChildNotifs = NotificationUtils.getTreeMapOfChildNotifications(context);
+      if (activeChildNotifs.size() == 0)
+         return;
+
+      try {
+         // Remove the most recent child notification from the shade and fires it's intent
+         NotificationUtils.ChildNotification mostRecentNotif = activeChildNotifs.firstEntry().getValue();
+         NotificationUtils.cancelNotification(context, mostRecentNotif.id);
+         mostRecentNotif.contentIntent.send();
+      } catch (PendingIntent.CanceledException e) {
+         e.printStackTrace();
+      }
+   }
+}


### PR DESCRIPTION
* This example setups a custom Summary notification for Android 7.0 + devices
* When tapping on the summary notification the most recent notification will be counted as opened and will be removed from the shade.
* The creation modifications are;
  - Adding setGroup to all child notifications
  - Create a custom group summary notification.
* The notification summary notification has its own Intent which will fire a broadcast.
   - This broadcast finds the newest notification, removes it from the shade, and fires it's open intent.
* Each time the app is resumed or from the notification open handler we also check if the summary notification has any children.
  - If no we remove the summary notification from the shade.
  - The only time this should be necessary is when opening a notification when it is the only one left part of the group.